### PR TITLE
Makefile: Change order when creating the executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ all : $(NAME)
 
 $(NAME):	$(LIBEXT) $(OBJS)
 	@echo "$(YELLOW)Creating executable..$(DEFAULT)"
-	@$(CC) $(OFLAGS) $^ -o $(NAME)
+	@$(CC) $(OFLAGS) $(OBJS) $(LIBEXT) -o $(NAME)
 	@echo "$(GREEN)---> $(NAME) is ready$(DEFAULT)"
 
 $(OBJD)/%.o : %.c | $(OBJD)


### PR DESCRIPTION
Now, the program compile on Linux and Darwin, before just on Darwin
```diff
-       @$(CC) $(OFLAGS) $(LIBEXT)  $(OBJS) -o $(NAME)
+       @$(CC) $(OFLAGS) $(OBJS) $(LIBEXT) -o $(NAME)
```
