### PR TITLE
Check map errors (leaks from mlx_init)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ SRCS	+=	$(SRCD)/check_map.c
 SRCS	+=	$(SRCD)/close.c
 SRCS	+=	$(SRCD)/parsing.c
 SRCS	+=	$(SRCD)/init.c
+SRCS	+=	$(SRCD)/init_window.c
 SRCS	+=	$(SRCD)/mini_map.c
 SRCS	+=	$(SRCD)/parse_utils.c
 SRCS	+=	$(SRCD)/player.c

--- a/headers/cub3d.h
+++ b/headers/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: gudias <marvin@42lausanne.ch>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/17 18:51:07 by gudias            #+#    #+#             */
-/*   Updated: 2022/09/01 18:14:57 by melogr@phy       ###   ########.fr       */
+/*   Updated: 2022/09/03 11:30:55 by melogr@phy       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -116,6 +116,9 @@ int		load_map(t_info *info, char *mapname);
 
 // init.c
 int		init_game(t_info *info);
+
+// init.c
+int		init_window(t_info *info);
 
 // mini_map.c
 void	print_minimap(t_info *info);

--- a/srcs/init.c
+++ b/srcs/init.c
@@ -6,40 +6,11 @@
 /*   By: gudias <marvin@42lausanne.ch>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/20 17:44:17 by gudias            #+#    #+#             */
-/*   Updated: 2022/09/01 15:11:29 by gudias           ###   ########.fr       */
+/*   Updated: 2022/09/03 11:30:24 by melogr@phy       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "cub3d.h"
-
-// Check if the texture is a square
-static int	check_square(int height, int width)
-{
-	if (height != width)
-		return (error_msg("Texture of the mini map is not a square"));
-	return (0);
-}
-
-// Load textures for the mini map
-static int	load_textures(t_info *info)
-{
-	int		img_width;
-	int		img_height;
-
-	info->mm_img[GROUND] = mlx_xpm_file_to_image
-		(info->mlx[INIT], MM_GROUND, &img_width, &img_height);
-	if (check_square(img_height, img_width))
-		return (1);
-	info->mm_img[WALL] = mlx_xpm_file_to_image
-		(info->mlx[INIT], MM_WALL, &img_width, &img_height);
-	if (check_square(img_height, img_width))
-		return (1);
-	info->mm_img[PLAYER] = mlx_xpm_file_to_image
-		(info->mlx[INIT], MM_PLAYER, &img_width, &img_height);
-	if (check_square(img_height, img_width))
-		return (1);
-	return (0);
-}
 
 // Init default value of the struct
 // Init mlx
@@ -55,10 +26,5 @@ int	init_game(t_info *info)
 	info->texture.west = NULL;
 	info->texture.floor = NULL;
 	info->texture.ceil = NULL;
-	info->mlx[INIT] = mlx_init();
-	if (!info->mlx[INIT])
-		return (error_msg("Couldn't init mlx"));
-	if (load_textures(info))
-		return (1);
 	return (0);
 }

--- a/srcs/init_window.c
+++ b/srcs/init_window.c
@@ -1,0 +1,52 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   init_window.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: melogr@phy <tgrivel@student.42lausanne.ch  +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/09/03 11:26:54 by melogr@phy        #+#    #+#             */
+/*   Updated: 2022/09/03 11:28:35 by melogr@phy       ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "cub3d.h"
+
+// Check if the texture is a square
+static int	check_square(int height, int width)
+{
+	if (height != width)
+		return (error_msg("Texture of the mini map is not a square"));
+	return (0);
+}
+
+// Load textures for the mini map
+static int	load_textures(t_info *info)
+{
+	int		img_width;
+	int		img_height;
+
+	info->mm_img[GROUND] = mlx_xpm_file_to_image
+		(info->mlx[INIT], MM_GROUND, &img_width, &img_height);
+	if (check_square(img_height, img_width))
+		return (1);
+	info->mm_img[WALL] = mlx_xpm_file_to_image
+		(info->mlx[INIT], MM_WALL, &img_width, &img_height);
+	if (check_square(img_height, img_width))
+		return (1);
+	info->mm_img[PLAYER] = mlx_xpm_file_to_image
+		(info->mlx[INIT], MM_PLAYER, &img_width, &img_height);
+	if (check_square(img_height, img_width))
+		return (1);
+	return (0);
+}
+
+int	init_window(t_info *info)
+{
+	info->mlx[INIT] = mlx_init();
+	if (!info->mlx[INIT])
+		return (error_msg("Couldn't init mlx"));
+	if (load_textures(info))
+		return (1);
+	return (0);
+}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -37,6 +37,8 @@ int	main(int ac, char **av)
 		ft_printf("%s", info.map[i]);
 		i++;
 	}
+	if (init_window(&info))
+		return (1);
 	if (start_window(&info))
 		return (1);
 	return (0);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: gudias <marvin@42lausanne.ch>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/17 18:47:21 by gudias            #+#    #+#             */
-/*   Updated: 2022/08/31 18:34:20 by gudias           ###   ########.fr       */
+/*   Updated: 2022/09/03 11:32:23 by melogr@phy       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,15 +31,11 @@ int	main(int ac, char **av)
 	//print map informations
 	printf("NO: %s\nSO: %s\nEA: %s\nWE: %s\nF: %s\nC: %s\n", info.texture.north, info.texture.south, info.texture.east, info.texture.west, info.texture.floor, info.texture.ceil);
 	
-	//print the map	
-	if (info.map)
+	i = 0;
+	while (info.map[i])
 	{
-		i = 0;
-		while (info.map[i])
-		{
-			ft_printf("%s", info.map[i]);
-			i++;
-		}
+		ft_printf("%s", info.map[i]);
+		i++;
 	}
 	if (start_window(&info))
 		return (1);


### PR DESCRIPTION
# Change the main order

I found leak when I execute `test.sh`
example:
```
$ ./cub3d invalid/twoplayer.cub
Cub3D
Error
More than 1 player

=================================================================
==3749==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 136 byte(s) in 1 object(s) allocated from:
    #0 0x7f78d96bfa89 in __interceptor_malloc /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x5590dc8c0e5a in mlx_init (/home/user/cub3d/cub3d+0x8e5a)
    #2 0x5590dc8bf5c2 in main srcs/main.c:25
    #3 0x7f78d93542cf  (/usr/lib/libc.so.6+0x232cf)

Indirect leak of 136 byte(s) in 1 object(s) allocated from:
    #0 0x7f78d96bf411 in __interceptor_calloc /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x7f78d9e57b04 in XShmCreateImage (/usr/lib/libXext.so.6+0x4b04)

Indirect leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7f78d96bf411 in __interceptor_calloc /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:77
    #1 0x5590dc8c2d37 in mlx_int_new_xshm_image (/home/user/cub3d/cub3d+0xad37)

SUMMARY: AddressSanitizer: 360 byte(s) leaked in 3 allocation(s).
```

## Before

1. Init game
   * Set default value
   * Init the window
   * Load texture
2. Parsing
   * Check parsing error
      > If we leave the program, we can't free the pointer from `mlx_init()`

## Now

1. Init game
   * Set default value
2. Parsing
   * Check parsing error
3. Init the window
   * Init the window
   * Load texture
