### PR TITLE
Load textures(Fixed bugs)

### DIFF
--- a/headers/cub3d.h
+++ b/headers/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: gudias <marvin@42lausanne.ch>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/17 18:51:07 by gudias            #+#    #+#             */
-/*   Updated: 2022/09/05 23:39:57 by melogr@phy       ###   ########.fr       */
+/*   Updated: 2022/09/05 23:51:46 by melogr@phy       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -151,7 +151,7 @@ void	player_move(t_info *info, float distance);
 void	player_rotate(t_info *info, float rotation);
 
 // textures.c
-int	load_textures(t_info *info);
+int		load_textures(t_info *info);
 
 //utils_mlx.c
 void	my_destroy_image(void *mlx, void *img);

--- a/headers/cub3d.h
+++ b/headers/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: gudias <marvin@42lausanne.ch>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/17 18:51:07 by gudias            #+#    #+#             */
-/*   Updated: 2022/09/05 23:51:46 by melogr@phy       ###   ########.fr       */
+/*   Updated: 2022/09/06 10:33:40 by gudias           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -134,8 +134,7 @@ int		check_map_data(t_info *info);
 //close.c
 void	free_array(char **array);
 int		error_msg(char *msg);
-void	exit_error(char *msg);
-int		close_game(t_info *info, int exit_code);
+void	close_game(t_info *info, int exit_code);
 
 // parsing.c
 int		load_map(t_info *info, char *mapname);

--- a/headers/cub3d.h
+++ b/headers/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: gudias <marvin@42lausanne.ch>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/17 18:51:07 by gudias            #+#    #+#             */
-/*   Updated: 2022/09/05 19:03:20 by gudias           ###   ########.fr       */
+/*   Updated: 2022/09/05 23:39:57 by melogr@phy       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -135,7 +135,7 @@ int		check_map_data(t_info *info);
 void	free_array(char **array);
 int		error_msg(char *msg);
 void	exit_error(char *msg);
-int		close_game(t_info *info);
+int		close_game(t_info *info, int exit_code);
 
 // parsing.c
 int		load_map(t_info *info, char *mapname);

--- a/srcs/close.c
+++ b/srcs/close.c
@@ -6,7 +6,7 @@
 /*   By: gudias <marvin@42lausanne.ch>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/20 17:45:50 by gudias            #+#    #+#             */
-/*   Updated: 2022/09/05 23:36:06 by melogr@phy       ###   ########.fr       */
+/*   Updated: 2022/09/06 10:32:37 by gudias           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,7 +58,7 @@ int	error_msg(char *msg)
 	return (1);
 }
 
-int	close_game(t_info *info, int exit_code)
+void	close_game(t_info *info, int exit_code)
 {
 	free_array(info->map);
 	if (info->mlx[WINDOW])
@@ -66,5 +66,4 @@ int	close_game(t_info *info, int exit_code)
 	destroy_images(info);
 	free_textures_path(info);
 	exit(exit_code);
-	return (0);
 }

--- a/srcs/close.c
+++ b/srcs/close.c
@@ -6,7 +6,7 @@
 /*   By: gudias <marvin@42lausanne.ch>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/20 17:45:50 by gudias            #+#    #+#             */
-/*   Updated: 2022/09/05 18:56:45 by gudias           ###   ########.fr       */
+/*   Updated: 2022/09/05 23:36:06 by melogr@phy       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,13 +58,13 @@ int	error_msg(char *msg)
 	return (1);
 }
 
-int	close_game(t_info *info)
+int	close_game(t_info *info, int exit_code)
 {
 	free_array(info->map);
 	if (info->mlx[WINDOW])
 		mlx_destroy_window(info->mlx[INIT], info->mlx[WINDOW]);
 	destroy_images(info);
 	free_textures_path(info);
-	exit(0);
+	exit(exit_code);
 	return (0);
 }

--- a/srcs/init.c
+++ b/srcs/init.c
@@ -6,7 +6,7 @@
 /*   By: gudias <marvin@42lausanne.ch>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/20 17:44:17 by gudias            #+#    #+#             */
-/*   Updated: 2022/09/02 14:46:00 by gudias           ###   ########.fr       */
+/*   Updated: 2022/09/05 23:31:44 by melogr@phy       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,15 @@ int	init_game(t_info *info, char *mapname)
 	info->texture[WE].path = NULL;
 	info->texture[FL].path = NULL;
 	info->texture[CE].path = NULL;
+	info->texture[NO].img = NULL;
+	info->texture[SO].img = NULL;
+	info->texture[EA].img = NULL;
+	info->texture[WE].img = NULL;
+	info->texture[FL].img = NULL;
+	info->texture[CE].img = NULL;
 	info->mlx[INIT] = mlx_init();
+	info->mlx[WINDOW] = 0;
+	ft_memset(&(info->mm_img), 0, (sizeof(void *) * 3));
 	if (!info->mlx[INIT])
 		return (error_msg("Couldn't init mlx"));
 	if (load_map(info, mapname) || load_textures(info))

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: gudias <marvin@42lausanne.ch>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/17 18:47:21 by gudias            #+#    #+#             */
-/*   Updated: 2022/09/02 16:40:55 by gudias           ###   ########.fr       */
+/*   Updated: 2022/09/05 23:36:45 by melogr@phy       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ int	main(int ac, char **av)
 		exit(error_msg("Invalid argument"));
 
 	if (init_game(&info, av[1]))
-		close_game(&info);
+		close_game(&info, 1);
 	
 	//print map informations
 	printf("NO: %s\nSO: %s\nEA: %s\nWE: %s\nF: %s\nC: %s\n", info.texture[NO].path, info.texture[SO].path, info.texture[EA].path, info.texture[WE].path, info.texture[FL].path, info.texture[CE].path);
@@ -39,6 +39,6 @@ int	main(int ac, char **av)
 		}
 	}
 	if (start_window(&info))
-		close_game(&info);
+		close_game(&info, 1);
 	return (0);
 }

--- a/srcs/mini_map.c
+++ b/srcs/mini_map.c
@@ -6,7 +6,7 @@
 /*   By: user42 <user42@42lausanne.ch>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/20 12:16:47 by user42            #+#    #+#             */
-/*   Updated: 2022/09/01 14:57:19 by gudias           ###   ########.fr       */
+/*   Updated: 2022/09/05 23:44:53 by melogr@phy       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,14 +56,21 @@ static void	print_player(t_info *info)
 static void	print_info(t_info *info)
 {
 	char	*tmp;
+	char	*itoa;
 
-	tmp = ft_strjoin("Position X: ", ft_itoa((int)info->player.x));
+	itoa = ft_itoa((int)info->player.x);
+	tmp = ft_strjoin("Position X: ", itoa);
+	free(itoa);
 	mlx_string_put(info->mlx[INIT], info->mlx[WINDOW], 500, 10, CO_WHITE, tmp);
 	free(tmp);
-	tmp = ft_strjoin("Position Y: ", ft_itoa((int)info->player.y));
+	itoa = ft_itoa((int)info->player.y);
+	tmp = ft_strjoin("Position Y: ", itoa);
+	free(itoa);
 	mlx_string_put(info->mlx[INIT], info->mlx[WINDOW], 500, 20, CO_WHITE, tmp);
 	free(tmp);
-	tmp = ft_strjoin("    Angle : ", ft_itoa((int)info->player.angle));
+	itoa = ft_itoa((int)info->player.angle);
+	tmp = ft_strjoin("    Angle : ", itoa);
+	free(itoa);
 	mlx_string_put(info->mlx[INIT], info->mlx[WINDOW], 500, 30, CO_WHITE, tmp);
 	free(tmp);
 }

--- a/srcs/window.c
+++ b/srcs/window.c
@@ -6,7 +6,7 @@
 /*   By: melogr@phy <tgrivel@student.42lausanne.ch  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/08/17 22:01:59 by melogr@phy        #+#    #+#             */
-/*   Updated: 2022/08/30 12:20:17 by tgrivel          ###   ########.fr       */
+/*   Updated: 2022/09/05 23:40:09 by melogr@phy       ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@ static int
 	deal_key(int key, void *info)
 {
 	if (key == KEY_ESC)
-		close_game(info);
+		close_game(info, 0);
 	else if (key == KEY_W || key == KEY_UP)
 		player_move(info, PS_MOVE);
 	else if (key == KEY_S || key == KEY_DOWN)
@@ -26,6 +26,13 @@ static int
 		player_rotate(info, PS_ROTATE);
 	else if (key == KEY_A || key == KEY_LEFT)
 		player_rotate(info, -PS_ROTATE);
+	return (0);
+}
+
+// Close the game with  an exit code of 0
+static int	red_cross(t_info *info)
+{
+	close_game(info, 0);
 	return (0);
 }
 
@@ -39,7 +46,7 @@ int	start_window(t_info *info)
 	if (!info->mlx[WINDOW])
 		return (error_msg("Couldn't create window"));
 	mlx_hook(info->mlx[WINDOW], 2, 1, deal_key, info);
-	mlx_hook(info->mlx[WINDOW], 17, 0L << 0, close_game, info);
+	mlx_hook(info->mlx[WINDOW], 17, 0L << 0, red_cross, info);
 	print_minimap(info);
 	mlx_loop(info->mlx[INIT]);
 	return (0);


### PR DESCRIPTION
### Bugs fixed

* `./cub3d complex_map.cub` `ft_itoa()` leaked
  Just free the allocate memory of `ft_itoa()`
* `./cub3d nomap.cub` `SEGV on unknown address`

  ```log
  $ ./cub3d nomap.cub       
  Cub3D
  Error
  Couldn't find map in assets/maps/
  AddressSanitizer:DEADLYSIGNAL
  =================================================================
  ==24960==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x7f995dcdc9e5 bp 0x621000000100 sp 0x7ffd16cf7900 T0)
  ==24960==The signal is caused by a READ memory access.
  ==24960==Hint: this fault was caused by a dereference of a high value address (see register values below).  Disassemble the provided pc to learn which register was used.
      #0 0x7f995dcdc9e5 in XFreeGC (/usr/lib/libX11.so.6+0x1f9e5)
      #1 0x55626230608a in mlx_destroy_window (/home/user/my-configuration/arch/cub3d/cub3d+0xb08a)
      #2 0x556262302f5d in close_game srcs/close.c:65
      #3 0x5562623025f0 in main srcs/main.c:26
      #4 0x7f995da112cf  (/usr/lib/libc.so.6+0x232cf)
      #5 0x7f995da11389 in __libc_start_main (/usr/lib/libc.so.6+0x23389)
      #6 0x556262302494 in _start ../sysdeps/x86_64/start.S:115
  
  AddressSanitizer can not provide additional info.
  SUMMARY: AddressSanitizer: SEGV (/usr/lib/libX11.so.6+0x1f9e5) in XFreeGC
  ==24960==ABORTING
  ```
  Set to 0 all images pointer in `init.c`
* `close_game()` exit always 0
  Added `int exit_code` as argument in `close_game()`