### PR TITLE
Improved init.c

### DIFF
--- a/srcs/check_map.c
+++ b/srcs/check_map.c
@@ -14,7 +14,7 @@
 
 static int	save_player_info(t_info *info, int x, int y)
 {
-	if (info->player.pos[X] != -1.0f)
+	if (info->player.pos[X] != 0.0f)
 		return (error_msg("More than 1 player"));
 	else
 	{
@@ -91,7 +91,7 @@ int	check_map_data(t_info *info)
 		if (check_charset(info, y) || check_borders(info, y))
 			return (1);
 	}
-	if (info->player.pos[X] == -1.0f)
+	if (info->player.pos[X] == 0.0f)
 		return (error_msg("No player in the map"));
 	return (0);
 }

--- a/srcs/init.c
+++ b/srcs/init.c
@@ -31,7 +31,6 @@ int	init_game(t_info *info, char *mapname)
 {
 	ft_memset(info, 0, (sizeof(t_info)));
 	info->active_map = true;
-	info->player.pos[X] = -1.0f;
 	info->player.delta[X] = -1.0f;
 	info->player.delta[Y] = -1.0f;
 	init_ray(info);

--- a/srcs/init.c
+++ b/srcs/init.c
@@ -34,11 +34,13 @@ int	init_game(t_info *info, char *mapname)
 	info->player.pos[X] = -1.0f;
 	info->player.delta[X] = -1.0f;
 	info->player.delta[Y] = -1.0f;
-	info->mlx[INIT] = mlx_init();
 	init_ray(info);
+	if (load_map(info, mapname))
+		return (1);
+	info->mlx[INIT] = mlx_init();
 	if (!info->mlx[INIT])
 		return (error_msg("Couldn't init mlx"));
-	if (load_map(info, mapname) || load_textures(info))
+	if (load_textures(info))
 		return (1);
 	return (0);
 }


### PR DESCRIPTION
### Change init order

If the map was invalid, `mlx_init()` was call.
Better way to check the map before to call `mlx_init()`

0. Init default value
1. Read and check the map
2. `mlx_init()`
3. Load texture

### Change default value of player.x
    
The default value is equal to 0
